### PR TITLE
Fix navbar width

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -343,7 +343,7 @@ h1, h2, h3, h4 {
         /* border: 2px solid red; */
         display: grid;
         grid-gap: 1.4rem;
-        grid-template-columns: minmax(auto, 280px) 1fr;
+        grid-template-columns: minmax(auto, 240px) 1fr;
     }
     
     .navbar-panel {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -35,7 +35,7 @@
               <button class="navbar-icon navbar-icon--close" id="navbarClose" type="button" aria-controls="navbarPanel">
                 <i class="fas fa-times"></i>
               </button>
-              <h1 class="navbar-panel-logo"><a class="navbar-panel-logo__text" href="{{ url_for('index') }}">homeschool journal</a></h1>
+              <h1 class="navbar-panel-logo"><a class="navbar-panel-logo__text" href="{{ url_for('index') }}">homeschool<br>journal</a></h1>
               <ul class="navbar-list">
                 <li class="nav-item">
                   <a class="nav-item--link" href="{{ url_for('log') }}"><i class="fas fa-fw fa-star menu-icon"></i>Activities</a>


### PR DESCRIPTION
This PR fixes the navbar width so it doesn't overlap with main page content

-  Add line break to homeschool journal logo text
- Decrease grid column width

![image](https://user-images.githubusercontent.com/13966892/124938671-7c84b780-dfd6-11eb-935a-781a88ee468b.png)
